### PR TITLE
WIP: Smaller Emphasis on Hashcash

### DIFF
--- a/views/layouts/default.jade
+++ b/views/layouts/default.jade
@@ -51,6 +51,8 @@ html
           small <a href="http://github.com/martindale/maki">Made</a> with care by <a href="http://www.ericmartindale.com/">Eric Martindale</a>.
 
     script.
+      $('.ui.accordion').accordion();
+      
       $(window).load(function(e) {
         console.log('match:', window.location.hash.match(/^#comment$/));
         if (window.location.hash && window.location.hash.match(/^#comment$/)) {

--- a/views/mixins/post.jade
+++ b/views/mixins/post.jade
@@ -22,9 +22,15 @@ mixin PostView(post, maxWords, samePage)
       else
         .description(style="clear: none;") !{ markdown(post.description) }
     
-    .extra.content
-      code(style="word-wrap: break-word;") #{post.hashcash}
-    
+    if (post.hashcash)
+      .extra.content
+        .ui.accordion
+          .title
+            i.dropdown.icon
+            | #{post.hashcash.substring(0, 20)}&hellip;
+          .content
+            code(style="word-wrap: break-word;") #{post.hashcash}
+
     .extra.content
       a(href="/posts/#{post._id}#comments")
         i.comment.icon

--- a/views/post.jade
+++ b/views/post.jade
@@ -31,8 +31,14 @@ block content
               | at 
               abbr.tooltipped(title="We require a proof-of-work for posting content on Converse.  Your computer performs a complex calculation that, once it meets a certain threshold (the difficulty score), allows your content to be posted.") difficulty #{comment.hashcash.split(':')[1]}
           .description(style="clear: none;") !{ markdown(comment.content || '') }
-        .extra.content
-          code(style="word-wrap: break-word;") #{comment.hashcash}
+        if (comment.hashcash)
+          .extra.content
+            .ui.accordion
+              .title
+                i.dropdown.icon
+                | #{comment.hashcash.substring(0, 20)}&hellip;
+              .content
+                code(style="word-wrap: break-word;") #{comment.hashcash}
         .extra.content
           a(href="/comments/#{comment._id}#comments")
             i.comment.icon


### PR DESCRIPTION
This reduces the screen real-estate dedicated to displaying the full proof of work for content.  This should undergo another pass from a better UX engineer than I.
