### PR TITLE
WIP: DATT

### DIFF
--- a/converse.js
+++ b/converse.js
@@ -461,18 +461,9 @@ Vote.on('vote', function(vote) {
     if (!stats.length) return;
     var meta = stats[0];
 
-    console.log('id:', vote._target);
-    console.log('err:', err);
-    console.log('stats:', stats);
-
     opts[ vote.context ].get({ _id: vote._target }, function(err, item) {
       var hotness = hotScore(meta.ups, meta.downs, item.created);
       var wilson = wilsonScore(meta.ups, meta.downs);
-
-      console.log('date:', item.created);
-      console.log('WE HAVE ARRIVED:', meta);
-      console.log('hot score:', hotness);
-      console.log('wilson score:', wilson);
 
       opts[ vote.context ].patch({
         _id: vote._target

--- a/converse.js
+++ b/converse.js
@@ -53,7 +53,7 @@ var Person = converse.define('Person', {
         return { _author: person._id };
       },
       populate: '_author _document',
-      sort: '-score -created'
+      sort: '-created'
     },
     'Save': {
       filter: function() {
@@ -95,6 +95,7 @@ var Post = converse.define('Post', {
     score:       { type: Number , required: true , default: 0 },
     _document:     { type: ObjectId , ref: 'Document', populate: ['get', 'query'] },
     stats:       {
+      wilson:    { type: Number , default: 0 },
       hotness:   { type: Number , default: 0 },
       comments:  { type: Number , default: 0 },
     },
@@ -109,7 +110,7 @@ var Post = converse.define('Post', {
         return { _post: post._id , _parent: { $exists: false } };
       },
       populate: '_author _parent',
-      sort: '-score -created'
+      sort: '-stats.wilson'
     }
   },
   icon: 'pin'
@@ -188,6 +189,7 @@ var Comment = converse.define('Comment', {
     content: { type: String, min: 1 },
     score: { type: Number , required: 0 , default: 0 },
     stats: {
+      wilson:   { type: Number , default: 0 },
       hotness:  { type: Number , default: 0 },
       comments: { type: Number , default: 0 },
       gildings: { type: Number , default: 0 },
@@ -331,6 +333,18 @@ Vote.on('vote', function(vote) {
     return order - secAge / decay;
   }
 
+  function wilsonScore(ups, downs) {
+    var z = 1.96;
+    var n = ups + downs;
+    if (n === 0) {
+      return 0;
+    }
+
+    var p = ups / n;
+    var zzfn = z*z / (4*n);
+    return (p + 2*zzfn - z*Math.sqrt((zzfn / n + p*(1 - p))/n)) / (1 + 4*zzfn);
+  }
+
   Vote.Model.aggregate([
     { $match: { _target: new UUID(vote._target) } },
     { $group: {
@@ -350,12 +364,18 @@ Vote.on('vote', function(vote) {
   ], function(err, stats) {
     var meta = stats[0];
 
+    console.log('id:', vote._target);
+    console.log('err:', err);
+    console.log('stats:', stats);
+
     opts[ vote.context ].get({ _id: vote._target }, function(err, item) {
       var hotness = hotScore(meta.ups, meta.downs, item.created);
+      var wilson = wilsonScore(meta.ups, meta.downs);
 
       console.log('date:', item.created);
-      console.log('WE HAVE ARRIVED:', stats);
+      console.log('WE HAVE ARRIVED:', meta);
       console.log('hot score:', hotness);
+      console.log('wilson score:', wilson);
 
 
       if (err) return console.error(err);
@@ -364,7 +384,8 @@ Vote.on('vote', function(vote) {
         _id: vote._target
       }, [
         { op: 'replace', path: '/score', value: meta.score },
-        { op: 'replace', path: '/stats/hotness', value: hotness }
+        { op: 'replace', path: '/stats/hotness', value: hotness },
+        { op: 'replace', path: '/stats/wilson', value: wilson },
       ], function(err) {
         if (err) console.error(err);
       });

--- a/converse.js
+++ b/converse.js
@@ -314,14 +314,10 @@ var Vote = converse.define('Vote', {
 });
 
 Vote.on('vote', function(vote) {
-  console.log('vote event!');
-
   var opts = {
     'post': Post,
     'comment': Comment
   };
-
-  console.log('matching for...', vote._target );
 
   Vote.Model.aggregate([
     { $match: { _target: new UUID(vote._target) } },
@@ -330,8 +326,6 @@ Vote.on('vote', function(vote) {
       score: { $sum: '$amount' }
     } }
   ], function(err, stats) {
-    console.log('aggregate returning:', err, stats);
-
     if (err) return console.error(err);
     if (!stats.length) return;
     opts[ vote.context ].patch({

--- a/converse.js
+++ b/converse.js
@@ -95,6 +95,7 @@ var Post = converse.define('Post', {
     score:       { type: Number , required: true , default: 0 },
     _document:     { type: ObjectId , ref: 'Document', populate: ['get', 'query'] },
     stats:       {
+      hotness:   { type: Number , default: 0 },
       comments:  { type: Number , default: 0 },
       gildings:  { type: Number , default: 0 },
       gilded:    { type: Number , default: 0 },
@@ -173,8 +174,6 @@ Document.pre('create', function(next, done) {
     document.description = document.description || metadata.openGraph.description || metadata.general.description;
     document.image = metadata.openGraph.image;
 
-
-
     console.log('okay, saved:', document);
     next(err);
   });
@@ -191,6 +190,7 @@ var Comment = converse.define('Comment', {
     content: { type: String, min: 1 },
     score: { type: Number , required: 0 , default: 0 },
     stats: {
+      hotness:  { type: Number , default: 0 },
       comments: { type: Number , default: 0 },
       gildings: { type: Number , default: 0 },
       gilded:   { type: Number , default: 0 },
@@ -367,21 +367,51 @@ Vote.on('vote', function(vote) {
     'comment': Comment
   };
 
+  function hotScore(ups, downs, date) {
+    var decay = 45000;
+    var s = ups - downs;
+    var order = Math.log(Math.max(Math.abs(s), 1)) / Math.LN10;
+    var secAge = (Date.now() - date.getTime()) / 1000;
+    return order - secAge / decay;
+  }
+
   Vote.Model.aggregate([
     { $match: { _target: new UUID(vote._target) } },
     { $group: {
       _id: '$_target',
-      score: { $sum: '$amount' }
+      score: { $sum: '$amount' },
+      ups: {
+        $sum: {
+          $cond: [ { $gte: ['$amount', 1] }, 1 , 0 ]
+        }
+      },
+      downs: {
+        $sum: {
+          $cond: [ { $lte: ['$amount', -1] }, 1 , 0 ]
+        }
+      },
     } }
   ], function(err, stats) {
-    if (err) return console.error(err);
-    if (!stats.length) return;
-    opts[ vote.context ].patch({
-      _id: vote._target
-    }, [{
-      op: 'replace', path: '/score', value: stats[0].score
-    }], function(err) {
-      if (err) console.error(err);
+    var meta = stats[0];
+
+    opts[ vote.context ].get({ _id: vote._target }, function(err, item) {
+      var hotness = hotScore(meta.ups, meta.downs, item.created);
+
+      console.log('date:', item.created);
+      console.log('WE HAVE ARRIVED:', stats);
+      console.log('hot score:', hotness);
+
+
+      if (err) return console.error(err);
+      if (!stats.length) return;
+      opts[ vote.context ].patch({
+        _id: vote._target
+      }, [
+        { op: 'replace', path: '/score', value: meta.score },
+        { op: 'replace', path: '/stats/hotness', value: hotness }
+      ], function(err) {
+        if (err) console.error(err);
+      });
     });
   });
 });
@@ -498,7 +528,7 @@ converse.define('Index', {
     'Post': {
       filter: {},
       populate: '_author _document',
-      sort: '-score -created'
+      sort: '-stats.hotness'
     }
   }
 });

--- a/converse.js
+++ b/converse.js
@@ -96,6 +96,7 @@ var Post = converse.define('Post', {
     _document:     { type: ObjectId , ref: 'Document', populate: ['get', 'query'] },
     stats:       {
       comments:  { type: Number , default: 0 },
+      gildings:  { type: Number , default: 0 },
     },
     attribution: {
       _author: { type: ObjectId , ref: 'Person', populate: ['get', 'query'] }
@@ -189,7 +190,8 @@ var Comment = converse.define('Comment', {
     content: { type: String, min: 1 },
     score: { type: Number , required: 0 , default: 0 },
     stats: {
-      comments: { type: Number , default: 0 }
+      comments: { type: Number , default: 0 },
+      gildings: { type: Number , default: 0 },
     }
   },
   requires: {
@@ -303,16 +305,6 @@ var Notification = converse.define('Notification', {
   }
 });
 
-var Vote = converse.define('Vote', {
-  attributes: {
-    //status: { type: String , required: true , enum: ['pending', 'issued', 'failed'], default: 'pending' },
-    _user: { type: ObjectId , ref: 'Person', required: true },
-    _target: { type: ObjectId, required: true },
-    context: { type: String , enum: ['post', 'comment'] },
-    amount: { type: Number, required: true },
-  }
-});
-
 var Gilding = converse.define('Gilding', {
   attributes: {
     //status: { type: String , required: true , enum: ['pending', 'issued', 'failed'], default: 'pending' },
@@ -320,6 +312,16 @@ var Gilding = converse.define('Gilding', {
     _target: { type: ObjectId, required: true },
     context: { type: String , enum: ['post', 'comment'] },
     value: { type: Number, required: true },
+  }
+});
+
+var Vote = converse.define('Vote', {
+  attributes: {
+    //status: { type: String , required: true , enum: ['pending', 'issued', 'failed'], default: 'pending' },
+    _user: { type: ObjectId , ref: 'Person', required: true },
+    _target: { type: ObjectId, required: true },
+    context: { type: String , enum: ['post', 'comment'] },
+    amount: { type: Number, required: true },
   }
 });
 

--- a/converse.js
+++ b/converse.js
@@ -351,6 +351,9 @@ Gilding.post('create', function() {
   Gilding.emit('gilding', gilding);
 });
 
+// NOTE: this is strikingly similar to how the pre:create hook for Vote works,
+// and probably deserves some consolidation.  We'll also need atomic operations,
+// if not a full-on linked-list/blockchain-based accounting system.
 Gilding.pre('create', function(next, finalize) {
   var gilding = this;
   var COST = 50;
@@ -359,7 +362,6 @@ Gilding.pre('create', function(next, finalize) {
     deductFromUser,
     addToUser
   ], function(err, results) {
-    // Note: counterintuitive.  Err here is likely the vote, if it's an update
     if (err) return finalize(null, err);
     next();
   });

--- a/converse.js
+++ b/converse.js
@@ -313,6 +313,16 @@ var Vote = converse.define('Vote', {
   }
 });
 
+var Gilding = converse.define('Gilding', {
+  attributes: {
+    //status: { type: String , required: true , enum: ['pending', 'issued', 'failed'], default: 'pending' },
+    _user: { type: ObjectId , ref: 'Person', required: true },
+    _target: { type: ObjectId, required: true },
+    context: { type: String , enum: ['post', 'comment'] },
+    value: { type: Number, required: true },
+  }
+});
+
 Vote.on('vote', function(vote) {
   var opts = {
     'post': Post,

--- a/public/js/converse.js
+++ b/public/js/converse.js
@@ -87,7 +87,7 @@ $(document).on('click', '*[data-intent=upvote], *[data-intent=downvote]', functi
 
 });
 
-$(document).on('click', '*[data-intent=tip]', function(e) {
+$(document).on('click', '*[data-intent=gild]', function(e) {
   e.preventDefault();
 
   var $self = $(this);

--- a/public/js/converse.js
+++ b/public/js/converse.js
@@ -93,30 +93,30 @@ $(document).on('click', '*[data-intent=gild]', function(e) {
   var $self = $(this);
   var target = $self.data('target');
 
+  var AMOUNT = 50;
+
   var data = {
-    _from: $self.data('from'),
-    _to: $self.data('for'),
-    _for: target,
+    _user: $self.data('user'),
+    _target: target,
     context: $self.data('context'),
-    amount: 1
+    amount: AMOUNT
   };
 
-  $.post('/tips', data, function(tip, status, xhr) {
+  $('*[data-bind='+target+'][data-for=gildings]').each(function(i) {
+    var value = $(this).html();
+    $(this).html( parseInt(value) + 1 );
+  });
 
-    $('*[data-bind='+target+']').each(function(i) {
-      var value = $(this).html();
-      $(this).html( parseInt(value) + 1 );
-    });
+  $('*[data-bind=user-balance]').each(function(i) {
+    var value = $(this).html();
+    $(this).html( (parseInt(value) - AMOUNT).toFixed(2) );
+  });
 
-    $('*[data-bind=user-balance]').each(function(i) {
-      var value = $(this).html();
-      $(this).html( (parseInt(value) - 1).toFixed(2) );
-    });
-
+  $.post('/gildings', data, function(gilding, status, xhr) {
+    console.log('gilded!', gilding);
   }, 'json').error(function(xhr, text, error) {
-    var tip = JSON.parse(xhr.responseText);
-    if (tip.error) return alert(tip.error);
-
+    var gilding = JSON.parse(xhr.responseText);
+    if (gilding.error) return alert(gilding.error);
   });
 
 });

--- a/public/js/converse.js
+++ b/public/js/converse.js
@@ -66,11 +66,20 @@ $(document).on('click', '*[data-intent=upvote], *[data-intent=downvote]', functi
     sentiment: sentiment
   };
 
+  $('*[data-bind=user-balance]').each(function(i) {
+    var value = $(this).html();
+    $(this).html( (parseInt(value) - 1).toFixed(2) );
+  });
+
+  $('*[data-bind='+target+']').each(function(i) {
+    var originally = parseInt( $(this).html() );
+    $(this).data('originally', originally);
+    $(this).html( originally + sentiment );
+  });
+
   $.post('/votes', data, function(vote, status, xhr) {
-    $('*[data-bind='+target+']').each(function(i) {
-      var value = $(this).html();
-      $(this).html( parseInt(value) + sentiment );
-    });
+    console.log('voting request completed');
+    console.log(vote);
   }, 'json').error(function(xhr, text, error) {
     var vote = JSON.parse(xhr.responseText);
     if (vote.error) return alert(vote.error);

--- a/views/comment.jade
+++ b/views/comment.jade
@@ -42,6 +42,10 @@ block content
             a.ui.button(href="/comments/#{comment._parent}")
               i.tree.icon
               | parent
+        else
+          a.ui.button(href="/posts/#{comment._post}")
+            i.tree.icon
+            | parent
         a.ui.button(href="/comments/#{comment._id}#comments")
           i.comment.icon
           | #{comment.stats.comments} comments

--- a/views/comment.jade
+++ b/views/comment.jade
@@ -18,6 +18,9 @@ block content
           if (comment.hashcash)
             | at 
             abbr.tooltipped(title="We require a proof-of-work for posting content on Converse.  Your computer performs a complex calculation that, once it meets a certain threshold (the difficulty score), allows your content to be posted.") difficulty #{comment.hashcash.split(':')[1]}
+          .ui.mini.label.tooltipped(title="2 gilded a total of 2,400.21μ฿")
+            i.trophy.icon
+            |  2
         .description(style="clear: none;") !{ markdown(comment.content || '') }
       .ui.mini.bottom.attached.buttons
         a.ui.button(href="/comments/#{comment._id}")
@@ -26,6 +29,9 @@ block content
         a.ui.button(href="#", data-intent="save")
           i.bookmark.icon
           | save
+        a.ui.button(href="#", data-intent="gild")
+          i.trophy.icon
+          | gild
         if (comment._parent)
           if (comment._parent._id)
             a.ui.button(href="/comments/#{comment._parent._id}")
@@ -58,6 +64,9 @@ block content
             if (subcomment.hashcash)
               | at 
               abbr.tooltipped(title="We require a proof-of-work for posting content on Converse.  Your computer performs a complex calculation that, once it meets a certain threshold (the difficulty score), allows your content to be posted.") difficulty #{subcomment.hashcash.split(':')[1]}
+            .ui.mini.label.tooltipped(title="2 gilded a total of 2,400.21μ฿")
+              i.trophy.icon
+              |  2
           .description(style="clear: none;") !{ markdown(subcomment.content || '') }
         .ui.mini.bottom.attached.buttons
           a.ui.button(href="/comments/#{subcomment._id}")
@@ -66,6 +75,9 @@ block content
           a.ui.button(href="#", data-intent="save")
             i.bookmark.icon
             | save
+          a.ui.button(href="#", data-intent="gild")
+            i.trophy.icon
+            | gild
           if (subcomment._parent)
             if (subcomment._parent._id)
               a.ui.button(href="/comments/#{subcomment._parent._id}")

--- a/views/comment.jade
+++ b/views/comment.jade
@@ -18,9 +18,10 @@ block content
           if (comment.hashcash)
             | at 
             abbr.tooltipped(title="We require a proof-of-work for posting content on Converse.  Your computer performs a complex calculation that, once it meets a certain threshold (the difficulty score), allows your content to be posted.") difficulty #{comment.hashcash.split(':')[1]}
-          .ui.mini.label.tooltipped(title="2 gilded a total of 2,400.21μ฿")
-            i.trophy.icon
-            |  2
+          if (comment.stats.gildings)
+            .ui.mini.label.tooltipped(title="#{comment.stats.gildings} gilded a total of #{subcomment.stats.gilded}μ฿")
+              i.trophy.icon
+              |  #{comment.stats.gildings}
         .description(style="clear: none;") !{ markdown(comment.content || '') }
       .ui.mini.bottom.attached.buttons
         a.ui.button(href="/comments/#{comment._id}")
@@ -64,9 +65,10 @@ block content
             if (subcomment.hashcash)
               | at 
               abbr.tooltipped(title="We require a proof-of-work for posting content on Converse.  Your computer performs a complex calculation that, once it meets a certain threshold (the difficulty score), allows your content to be posted.") difficulty #{subcomment.hashcash.split(':')[1]}
-            .ui.mini.label.tooltipped(title="2 gilded a total of 2,400.21μ฿")
-              i.trophy.icon
-              |  2
+            if (subcomment.stats.gildings)
+              .ui.mini.label.tooltipped(title="#{subcomment.stats.gildings} gilded a total of #{subcomment.stats.gilded}μ฿")
+                i.trophy.icon
+                |  #{subcomment.stats.gildings}
           .description(style="clear: none;") !{ markdown(subcomment.content || '') }
         .ui.mini.bottom.attached.buttons
           a.ui.button(href="/comments/#{subcomment._id}")

--- a/views/layouts/default.jade
+++ b/views/layouts/default.jade
@@ -38,6 +38,11 @@ html
       .no-shadow .card {
         box-shadow: none;
       }
+      
+      .ui.mini.label,
+      .ui.mini.labels .label {
+        vertical-align: top;
+      }
 
     base(href="/")
 
@@ -46,14 +51,10 @@ html
       .row
         block navbar
           include ../partials/navbar
-
       .row
         .column.content(data-for="viewport")
-        
           include ../partials/flash
-        
           block content
-
       .row
         .ui.one.column.stackable.center.aligned
           p

--- a/views/layouts/default.jade
+++ b/views/layouts/default.jade
@@ -63,5 +63,8 @@ html
             strong decentralize <em>all</em> the things.
     
     script(src="/js/converse.js")
+    script(src="/js/bitcore.min.js")
+    script(src="/js/bitcore-mnemonic.min.js")
+    script(src="/js/bundle.js")
 
     block scripts

--- a/views/mixins/post.jade
+++ b/views/mixins/post.jade
@@ -11,7 +11,7 @@ mixin PostView(post, maxWords, samePage)
           if (post.stats.gildings)
             .ui.mini.label.tooltipped(title="#{post.stats.gildings} gilded a total of #{post.stats.gilded}μ฿")
               i.trophy.icon
-              | #{post.stats.gildings}
+              span(data-bind="#{post._id}", data-for="gildings") #{post.stats.gildings}
       .meta
         a(href="/posts/#{post._id}")
           abbr.date.tooltipped(title="#{ moment( post.created ).format('MMMM Do YYYY, h:mm:ss a') }") #{ moment( post.created ).fromNow() }
@@ -76,13 +76,16 @@ mixin PostView(post, maxWords, samePage)
         a.ui.button(href="#", data-intent="save", data-post="#{post._id}", data-user="#{user._id}")
           i.bookmark.icon
           | save
+        a.ui.button.tooltipped(href="#", data-intent="gild", data-target="#{post._id}", data-user="#{user._id}", data-context="post", title="Gives the author 50 bits, and marks the post as having been gilded.")
+          i.trophy.icon
+          | gild
       else
         a.ui.button.tooltipped(href="#", title="Sign in to save this to your bookmarks!")
           i.bookmark.icon
           | save
-      a.ui.button(href="#", data-intent="gild")
-        i.trophy.icon
-        | gild
+        a.ui.button.tooltipped(href="#", data-intent="gild", title="Sign in to gild this post!")
+          i.trophy.icon
+          | gild
       a.ui.button(href="#", data-intent="share")
         i.share.icon
         | share

--- a/views/mixins/post.jade
+++ b/views/mixins/post.jade
@@ -8,6 +8,9 @@ mixin PostView(post, maxWords, samePage)
       img.right.floated.mini.ui.avatar(src="https://thecatapi.com/api/images/get?format=src&type=gif")
       .header
         a(href="/posts/#{post._id}") #{post.name}
+          .ui.mini.label.tooltipped(title="2 gilded a total of 2,400.21μ฿")
+            i.trophy.icon
+            | 2
       .meta
         a(href="/posts/#{post._id}")
           abbr.date.tooltipped(title="#{ moment( post.created ).format('MMMM Do YYYY, h:mm:ss a') }") #{ moment( post.created ).fromNow() }
@@ -76,9 +79,9 @@ mixin PostView(post, maxWords, samePage)
         a.ui.button.tooltipped(href="#", title="Sign in to save this to your bookmarks!")
           i.bookmark.icon
           | save
-      a.ui.button(href="#", data-intent="tip")
-        i.bitcoin.icon
-        | tip
+      a.ui.button(href="#", data-intent="gild")
+        i.trophy.icon
+        | gild
       a.ui.button(href="#", data-intent="share")
         i.share.icon
         | share

--- a/views/mixins/post.jade
+++ b/views/mixins/post.jade
@@ -8,9 +8,10 @@ mixin PostView(post, maxWords, samePage)
       img.right.floated.mini.ui.avatar(src="https://thecatapi.com/api/images/get?format=src&type=gif")
       .header
         a(href="/posts/#{post._id}") #{post.name}
-          .ui.mini.label.tooltipped(title="2 gilded a total of 2,400.21μ฿")
-            i.trophy.icon
-            | 2
+          if (post.stats.gildings)
+            .ui.mini.label.tooltipped(title="#{post.stats.gildings} gilded a total of #{post.stats.gilded}μ฿")
+              i.trophy.icon
+              | #{post.stats.gildings}
       .meta
         a(href="/posts/#{post._id}")
           abbr.date.tooltipped(title="#{ moment( post.created ).format('MMMM Do YYYY, h:mm:ss a') }") #{ moment( post.created ).fromNow() }

--- a/views/post.jade
+++ b/views/post.jade
@@ -46,7 +46,7 @@ block content
           a.ui.button(href="#", data-intent="save")
             i.bookmark.icon
             | save
-          a.ui.button(href="#", data-intent="gild")
+          a.ui.button(href="#", data-intent="gild", data-target="#{comment._id}")
             i.trophy.icon
             | gild
           if (comment._parent)

--- a/views/post.jade
+++ b/views/post.jade
@@ -32,9 +32,10 @@ block content
             if (comment.hashcash)
               | at 
               abbr.tooltipped(title="We require a proof-of-work for posting content on Converse.  Your computer performs a complex calculation that, once it meets a certain threshold (the difficulty score), allows your content to be posted.") difficulty #{comment.hashcash.split(':')[1]}
-            .ui.mini.label.tooltipped(title="2 gilded a total of 2,400.21μ฿")
-              i.trophy.icon
-              |  2
+            if (comment.stats.gildings)
+              .ui.mini.label.tooltipped(title="#{comment.stats.gildings} gilded a total of #{comment.stats.gilded}μ฿")
+                i.trophy.icon
+                |  #{comment.stats.gildings}
           .description(style="clear: none;") !{ markdown(comment.content || '') }
         //-.extra.content
           code(style="word-wrap: break-word;") #{comment.hashcash}

--- a/views/post.jade
+++ b/views/post.jade
@@ -32,6 +32,9 @@ block content
             if (comment.hashcash)
               | at 
               abbr.tooltipped(title="We require a proof-of-work for posting content on Converse.  Your computer performs a complex calculation that, once it meets a certain threshold (the difficulty score), allows your content to be posted.") difficulty #{comment.hashcash.split(':')[1]}
+            .ui.mini.label.tooltipped(title="2 gilded a total of 2,400.21μ฿")
+              i.trophy.icon
+              |  2
           .description(style="clear: none;") !{ markdown(comment.content || '') }
         //-.extra.content
           code(style="word-wrap: break-word;") #{comment.hashcash}
@@ -42,6 +45,9 @@ block content
           a.ui.button(href="#", data-intent="save")
             i.bookmark.icon
             | save
+          a.ui.button(href="#", data-intent="gild")
+            i.trophy.icon
+            | gild
           if (comment._parent)
             a.ui.button(href="/comments/#{comment._parent}")
               i.tree.icon


### PR DESCRIPTION
This implements @bradleykam's monetary implications for both upvotes and downvotes, which function identically – in the event of a first-time vote, they now spend 1 bit from the user account, giving it to the content poster. If the user is voting for a second time, it updates the existing vote, with no movement of funds.
